### PR TITLE
Add StepInput & refine account displays

### DIFF
--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -139,8 +139,8 @@ const AccountCard: React.FC<AccountCardProps> = ({ account, onClaim, canClaim, s
         <div className="grid grid-cols-2 gap-4 mb-5">
           <div className="text-center p-2 bg-slate-50 rounded-lg">
             <TrendingUp size={18} className="text-green-600 mx-auto mb-1" />
-            <div className="font-bold text-green-600">{account.balance.toFixed(2)}</div>
-            <small className="text-slate-500 text-xs">TRX</small>
+            <div className="font-bold text-green-600">{account.balance.toFixed(6)}</div>
+            <small className="text-slate-500 text-xs">{account.baseUrl?.split('pick')[0].toLocaleUpperCase()}</small>
           </div>
           
           <div className="text-center p-2 bg-slate-50 rounded-lg">

--- a/src/components/AccountHistoryChart.tsx
+++ b/src/components/AccountHistoryChart.tsx
@@ -202,21 +202,21 @@ const AccountHistoryChart: React.FC<AccountHistoryChartProps> = ({ accountId, ac
       <div className="mt-3 grid grid-cols-3 gap-2 text-xs">
         <div className="text-center p-2 bg-blue-50 rounded">
           <div className="font-medium text-blue-700">
-            {sortedHistory.filter(h => h.action === 'claim').length}
+            {sortedHistory.length > 0 ? sortedHistory[0].balance.toFixed(6) : '0.000000'}
           </div>
-          <div className="text-slate-500">Claims</div>
+          <div className="text-slate-500">Avant</div>
         </div>
         <div className="text-center p-2 bg-purple-50 rounded">
           <div className="font-medium text-purple-700">
-            {sortedHistory.filter(h => h.action === 'game').length}
+            {sortedHistory.length > 0 ? sortedHistory[sortedHistory.length - 1].balance.toFixed(6) : '0.000000'}
           </div>
-          <div className="text-slate-500">Jeux</div>
+          <div className="text-slate-500">Après</div>
         </div>
         <div className="text-center p-2 bg-green-50 rounded">
           <div className="font-medium text-green-700">
-            {sortedHistory.reduce((sum, h) => sum + (h.claimAmount || 0), 0).toFixed(2)}
+            {sortedHistory.length > 0 ? (sortedHistory[0].balance - sortedHistory[sortedHistory.length - 1].balance).toFixed(6) : '0.000000'}
           </div>
-          <div className="text-slate-500">Total TRX</div>
+          <div className="text-slate-500">Total</div>
         </div>
       </div>
     </div>

--- a/src/components/RouletteBot.tsx
+++ b/src/components/RouletteBot.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import StepInput from './StepInput';
 import {
   Play,
   Square,
@@ -74,9 +75,9 @@ interface BotConfig {
 
 const DEFAULT_BOT_CONFIG: BotConfig = {
   strategy:        'none',
-  stop_loss:       0,
-  stop_win:        0,
-  stop_on_wagered: 0,
+  stop_loss:       0.0,
+  stop_win:        0.0,
+  stop_on_wagered: 0.0,
 };
 
 const BET_LABELS: Record<string, string> = {
@@ -839,15 +840,14 @@ const RouletteBot: React.FC<RouletteBotProps> = ({ accounts, showToast }) => {
                   </div>
                 </td>
                 <td className="px-4 py-3">
-                  <div className="flex items-center gap-2">
-                    <input
-                      type="number" min={0} step={0.0001}
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <StepInput
                       value={config.stop_loss}
-                      onChange={e => setField('stop_loss', Math.max(0, Number(e.target.value)))}
-                      className="w-28 px-3 py-1.5 rounded-lg border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-red-200"
-                      placeholder="0 = désactivé"
+                      onChange={v => setField('stop_loss', v)}
+                      step={0.0001}
+                      ringColor="focus:ring-red-200"
                     />
-                    <span className="text-slate-400 text-xs">jetons</span>
+                    <span className="text-slate-400 text-xs">TRX</span>
                     {config.stop_loss === 0 && <span className="text-xs text-slate-400 italic">désactivé</span>}
                   </div>
                 </td>
@@ -864,16 +864,14 @@ const RouletteBot: React.FC<RouletteBotProps> = ({ accounts, showToast }) => {
                   </div>
                 </td>
                 <td className="px-4 py-3">
-                  <div className="flex items-center gap-2">
-                    <input
-                      type="number" min={0}
-                      step={0.0001}
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <StepInput
                       value={config.stop_win}
-                      onChange={e => setField('stop_win', Math.max(0, Number(e.target.value)))}
-                      className="w-28 px-3 py-1.5 rounded-lg border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-green-200"
-                      placeholder="0 = désactivé"
+                      onChange={v => setField('stop_win', v)}
+                      step={0.0001}
+                      ringColor="focus:ring-green-200"
                     />
-                    <span className="text-slate-400 text-xs">jetons</span>
+                    <span className="text-slate-400 text-xs">TRX</span>
                     {config.stop_win === 0 && <span className="text-xs text-slate-400 italic">désactivé</span>}
                   </div>
                 </td>
@@ -890,15 +888,14 @@ const RouletteBot: React.FC<RouletteBotProps> = ({ accounts, showToast }) => {
                   </div>
                 </td>
                 <td className="px-4 py-3">
-                  <div className="flex items-center gap-2">
-                    <input
-                      type="number" min={0} step={0.0001}
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <StepInput
                       value={config.stop_on_wagered}
-                      onChange={e => setField('stop_on_wagered', Math.max(0, Number(e.target.value)))}
-                      className="w-28 px-3 py-1.5 rounded-lg border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-yellow-200"
-                      placeholder="0 = désactivé"
+                      onChange={v => setField('stop_on_wagered', v)}
+                      step={0.0001}
+                      ringColor="focus:ring-yellow-200"
                     />
-                    <span className="text-slate-400 text-xs">jetons</span>
+                    <span className="text-slate-400 text-xs">TRX</span>
                     {config.stop_on_wagered === 0 && <span className="text-xs text-slate-400 italic">désactivé</span>}
                   </div>
                 </td>

--- a/src/components/StepInput.tsx
+++ b/src/components/StepInput.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+interface StepInputProps {
+  value: number;
+  onChange: (v: number) => void;
+  step?: number;
+  min?: number;
+  ringColor?: string;
+  placeholder?: string;
+}
+
+const StepInput: React.FC<StepInputProps> = ({
+  value,
+  onChange,
+  step = 1,
+  min = 0,
+  ringColor = 'focus:ring-blue-200',
+  placeholder = '0 = désactivé',
+}) => {
+  const dec = () => onChange(Math.max(min, parseFloat((value - step).toFixed(6))));
+  const inc = () => onChange(parseFloat((value + step).toFixed(6)));
+
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        type="button"
+        onClick={dec}
+        className="w-8 h-8 flex items-center justify-center rounded-lg border border-slate-200 bg-slate-50 text-slate-600 hover:bg-slate-100 active:bg-slate-200 text-lg font-bold transition select-none"
+        aria-label="Diminuer"
+      >
+        −
+      </button>
+      <input
+        type="number"
+        min={min}
+        step={step}
+        value={value.toFixed(6)}
+        onChange={e => onChange(Number(Math.max(min, Number(e.target.value)).toFixed(6)))}
+        className={`w-28 px-3 py-1.5 rounded-lg border border-slate-200 text-sm focus:outline-none focus:ring-2 ${ringColor} text-center`}
+        placeholder={placeholder}
+      />
+      <button
+        type="button"
+        onClick={inc}
+        className="w-8 h-8 flex items-center justify-center rounded-lg border border-slate-200 bg-slate-50 text-slate-600 hover:bg-slate-100 active:bg-slate-200 text-lg font-bold transition select-none"
+        aria-label="Augmenter"
+      >
+        +
+      </button>
+    </div>
+  );
+};
+
+export default StepInput;


### PR DESCRIPTION
Introduce a reusable StepInput component and replace raw numeric inputs in RouletteBot with it (supports increment/decrement, step, min and ringColor). Update DEFAULT_BOT_CONFIG stop_* values to use floats. Adjust RouletteBot layout (flex-wrap), pass step and ring color props, and change unit labels from "jetons" to "TRX".

Also refine account UI: AccountCard now displays balances with 6 decimal places and derives currency label from account.baseUrl; AccountHistoryChart shows "Avant" (previous) and "Après" (current) balances with 6-decimal formatting and computes "Total" as the difference between those balances.